### PR TITLE
bug: update virtual processes catch errors and retry

### DIFF
--- a/src/virtual-customer/src/main.rs
+++ b/src/virtual-customer/src/main.rs
@@ -72,23 +72,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let order = Order { customer_id, items };
         let serialized_order = serde_json::to_string(&order)?;
         let client = reqwest::blocking::Client::new();
+
         let response = client
             .post(order_service_url.clone())
             .header("Content-Type", "application/json")
             .body(serialized_order.clone())
-            .send()?;
+            .send();
 
-        // track the time it takes to generate an order
-        let elapsed_time = start_time.elapsed();
+        match response {
+            Ok(res) => {
+                // Handle successful response
+                let elapsed_time = start_time.elapsed();
 
-        // print the order details
-        println!(
-            "Order {} sent at {:.2?} with status of {}. {}",
-            order_counter,
-            elapsed_time,
-            response.status(),
-            serialized_order
-        );
+                // print the order details
+                println!(
+                    "Order {} sent at {:.2?} with status of {}. {}",
+                    order_counter,
+                    elapsed_time,
+                    res.status(),
+                    serialized_order
+                );
+            }
+            Err(err) => {
+                // Handle error
+                println!("Failed to submit order: {}", err);
+            }
+        }
 
         thread::sleep(sleep_duration);
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
When services are not available virtual-customer and virtual-worker processes will fail and cause crashloopbackoff in k8s. Updated virtual-customer and virtual-worder projects to catch these errors and retry

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Redeploy the solution to K8s and confirm virtual-customer and virtual-worker containers have 0 restarts.