### PR TITLE
refactor: gh workflow to publish using gh token

### DIFF
--- a/.github/workflows/package-virtual-worker.yaml
+++ b/.github/workflows/package-virtual-worker.yaml
@@ -9,6 +9,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-container-image:
     
@@ -18,7 +22,7 @@ jobs:
       - name: Set environment variables
         id: set-variables
         run: |
-          echo "REPOSITORY=ghcr.io/azure-samples/aks-store-demo" >> "$GITHUB_OUTPUT"
+          echo "REPOSITORY=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
           echo "IMAGE=virtual-worker" >> "$GITHUB_OUTPUT"
           echo "VERSION=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
           echo "CREATED=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
@@ -41,8 +45,8 @@ jobs:
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}        
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}      
       
       - name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Update GH workflow to publish using `${{ github.token }}` instead of PAT stored in Action secrets

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Manually run the `package-virtual-worker` workflow

## What to Check
Verify that the following are valid
* Ensure the `virtual-worker` package is published

## Other Information
<!-- Add any other helpful information that may be needed here. -->