### PR TITLE
feat: enable workload identity for aoai auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,23 @@
 IMAGE_VERSION ?= 0.0.1-beta
+RANDOM := $(shell bash -c 'echo $$RANDOM')
+LOC_NAME ?= northcentralus
+RG_NAME ?= rg-store-demo-$(RANDOM)
+ACR_NAME ?= acrstoredemo$(RANDOM)
+AKS_NAME ?= aks-store-demo-$(RANDOM)
+AOAI_NAME ?= aoai-store-demo-$(RANDOM)
 
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: all 
-all: build load kustomize deploy ## Build all container images, load images into kind cluster, and deploy to kind cluster
+.PHONY: local 
+local: build load kustomize deploy ## Build all container images, load images into kind cluster, and deploy to kind cluster
+
+.PHONY: azure
+azure: provision-azure deploy-azure ## Provision Azure Resources, build all container images, push images to Azure Container Registry, and deploy to AKS cluster
+
+.PHONY: azure-ai
+azure-ai: provision-azure deploy-azure deploy-azure-ai ## Provision Azure Resources, build all container images, push images to Azure Container Registry, and deploy to AKS cluster with ai-service
 
 ##@ Build images
 
@@ -18,19 +30,86 @@ build: ./src/order-service/Dockerfile \
 	./src/virtual-customer/Dockerfile \
 	./src/virtual-worker/Dockerfile \
 	## Build all images
-	docker build -t order-service:$(IMAGE_VERSION) ./src/order-service
-	docker build -t makeline-service:$(IMAGE_VERSION) ./src/makeline-service
-	docker build -t product-service:$(IMAGE_VERSION) ./src/product-service
-	docker build -t store-front:$(IMAGE_VERSION) ./src/store-front
-	docker build -t store-admin:$(IMAGE_VERSION) ./src/store-admin
-	docker build -t virtual-customer:$(IMAGE_VERSION) ./src/virtual-customer
-	docker build -t virtual-worker:$(IMAGE_VERSION) ./src/virtual-worker
+	@docker build -t order-service:$(IMAGE_VERSION) ./src/order-service
+	@docker build -t makeline-service:$(IMAGE_VERSION) ./src/makeline-service
+	@docker build -t product-service:$(IMAGE_VERSION) ./src/product-service
+	@docker build -t store-front:$(IMAGE_VERSION) ./src/store-front
+	@docker build -t store-admin:$(IMAGE_VERSION) ./src/store-admin
+	@docker build -t virtual-customer:$(IMAGE_VERSION) ./src/virtual-customer
+	@docker build -t virtual-worker:$(IMAGE_VERSION) ./src/virtual-worker
+
+
+##@ Provision Azure Resources
+
+.PHONY: provision-azure
+provision-azure: ## Provision Azure Resources
+	@echo "Provisioning Azure Resources"
+	@az group create -n $(RG_NAME) -l $(LOC_NAME)
+	@az acr create -n $(ACR_NAME) -g $(RG_NAME) --sku Basic
+	@az aks create -n $(AKS_NAME) -g $(RG_NAME) --attach-acr $(ACR_NAME)
+	@az aks get-credentials -n $(AKS_NAME) -g $(RG_NAME)
+	@az cognitiveservices account create --name $(AOAI_NAME) -g $(RG_NAME) -l $(LOC_NAME) --kind OpenAI --sku S0 --custom-domain $(AOAI_NAME)
+	@az cognitiveservices account deployment create -n $(AOAI_NAME) -g $(RG_NAME) --deployment-name gpt-35-turbo --model-format OpenAI --model-name gpt-35-turbo --model-version 0613 --sku Standard --capacity 60
+	@az acr build -r $(ACR_NAME) -t order-service:$(IMAGE_VERSION) ./src/order-service
+	@az acr build -r $(ACR_NAME) -t makeline-service:$(IMAGE_VERSION) ./src/makeline-service
+	@az acr build -r $(ACR_NAME) -t product-service:$(IMAGE_VERSION) ./src/product-service
+	@az acr build -r $(ACR_NAME) -t store-front:$(IMAGE_VERSION) ./src/store-front
+	@az acr build -r $(ACR_NAME) -t store-admin:$(IMAGE_VERSION) ./src/store-admin
+	@az acr build -r $(ACR_NAME) -t virtual-customer:$(IMAGE_VERSION) ./src/virtual-customer
+	@az acr build -r $(ACR_NAME) -t virtual-worker:$(IMAGE_VERSION) ./src/virtual-worker
+	@az acr build -r $(ACR_NAME) -t ai-service:$(IMAGE_VERSION) ./src/ai-service
+
+.PHONY: deploy-azure
+deploy-azure: kustomize aks-store-all-in-one.yaml ## Deploy to AKS cluster
+	@$(KUSTOMIZE) create --resources aks-store-all-in-one.yaml
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/order-service=$(ACR_NAME).azurecr.io/order-service:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/makeline-service=$(ACR_NAME).azurecr.io/makeline-service:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/product-service=$(ACR_NAME).azurecr.io/product-service:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/store-front=$(ACR_NAME).azurecr.io/store-front:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/store-admin=$(ACR_NAME).azurecr.io/store-admin:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/virtual-customer=$(ACR_NAME).azurecr.io/virtual-customer:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/virtual-worker=$(ACR_NAME).azurecr.io/virtual-worker:$(IMAGE_VERSION)
+	@kubectl apply -k .
+
+.PHONY: deploy-azure-ai
+deploy-azure-ai: deploy-azure kustomize ai-service.yaml ## Deploy ai-service to AKS cluster
+	@# Remove existing kustomization.yaml and .env if they exist
+	@rm -f kustomization.yaml .env
+
+	@# Create kustomization.yaml and .env
+	@$(KUSTOMIZE) create --resources ai-service.yaml
+
+	@# Set image version
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/ai-service=$(ACR_NAME).azurecr.io/ai-service:$(IMAGE_VERSION)
+
+	@# Set environment variables
+	@echo "USE_AZURE_OPENAI=True" > .env
+	@echo "USE_AZURE_AD=False" >> .env
+	@echo "AZURE_OPENAI_DEPLOYMENT_NAME=gpt-35-turbo" >> .env
+	@echo "AZURE_OPENAI_ENDPOINT=$$(az cognitiveservices account show -n $(AOAI_NAME) -g $(RG_NAME) --query properties.endpoint -o tsv)" >> .env
+	@echo "OPENAI_API_KEY=$$(az cognitiveservices account keys list -n $(AOAI_NAME) -g $(RG_NAME) --query key1 -o tsv)" >> .env
+
+	@# Add configMapGenerator and patches to kustomization.yaml
+	@echo "configMapGenerator:\n- name: ai-service-configmap\n  envs:\n  - .env" >> kustomization.yaml
+
+	@# Add patches to kustomization.yaml
+	@echo "patches:\n- patch: |-\n    - op: remove\n      path: \"/spec/template/spec/containers/0/env\"\n    - op: add\n      path: \"/spec/template/spec/containers/0/envFrom\"\n      value:\n      - configMapRef:\n          name: ai-service-configmap\n  target:\n    kind: Deployment\n    name: ai-service" >> kustomization.yaml
+
+	@# Deploy to AKS cluster
+	@$(KUSTOMIZE) build . | kubectl apply -f -
+
+
+.PHONY: clean-azure
+clean-azure: ## Delete kind cluster and kustomization.yaml
+	@az group delete -n $(RG_NAME) -y --no-wait
+	@rm -f kustomization.yaml
+	@rm -rf $(LOCALBIN)
 
 ##@ Deploy to kind cluster
 
 .PHONY: load
 load: build kind ## Load all locally built containers into kind cluster
-	$(KIND) load docker-image \
+	@$(KIND) load docker-image \
 		order-service:$(IMAGE_VERSION) \
 		makeline-service:$(IMAGE_VERSION) \
 		product-service:$(IMAGE_VERSION) \
@@ -41,18 +120,18 @@ load: build kind ## Load all locally built containers into kind cluster
 
 .PHONY: manifest ## Create kustomization.yaml and set image versions to locally built images
 manifest: kustomize aks-store-all-in-one.yaml
-	$(KUSTOMIZE) create --resources aks-store-all-in-one.yaml
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/order-service=order-service:$(IMAGE_VERSION)
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/makeline-service=makeline-service:$(IMAGE_VERSION)
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/product-service=product-service:$(IMAGE_VERSION)
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/store-front=store-front:$(IMAGE_VERSION)
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/store-admin=store-admin:$(IMAGE_VERSION)
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/virtual-customer=virtual-customer:$(IMAGE_VERSION)
-	$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/virtual-worker=virtual-worker:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) create --resources aks-store-all-in-one.yaml
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/order-service=order-service:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/makeline-service=makeline-service:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/product-service=product-service:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/store-front=store-front:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/store-admin=store-admin:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/virtual-customer=virtual-customer:$(IMAGE_VERSION)
+	@$(KUSTOMIZE) edit set image ghcr.io/azure-samples/aks-store-demo/virtual-worker=virtual-worker:$(IMAGE_VERSION)
 
 .PHONY: deploy
 deploy: manifest ## Deploy to cluster
-	kubectl apply -k .
+	@kubectl apply -k .
 
 .PHONY: clean 
 clean: ## Delete kind cluster and kustomization.yaml
@@ -66,7 +145,7 @@ clean: ## Delete kind cluster and kustomization.yaml
 
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
-	mkdir -p $(LOCALBIN)
+	@mkdir -p $(LOCALBIN)
 
 # tools
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
@@ -86,17 +165,17 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	@test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary and create a new cluster. If wrong version is installed, it will be overwritten.
 $(KIND): $(LOCALBIN)
-	test -s $(LOCALBIN)/kind && $(LOCALBIN)/kind --version | grep -q $(KIND_VERSION) || \
+	@test -s $(LOCALBIN)/kind && $(LOCALBIN)/kind --version | grep -q $(KIND_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
 	@if [ `$(KIND) get clusters | wc -l` -eq 0 ]; then \
 		$(KIND) create cluster; \

--- a/ai-service.yaml
+++ b/ai-service.yaml
@@ -33,10 +33,10 @@ spec:
         resources:
           requests:
             cpu: 20m
-            memory: 46Mi
+            memory: 50Mi
           limits:
             cpu: 30m
-            memory: 50Mi
+            memory: 65Mi
 ---
 apiVersion: v1
 kind: Service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       - USE_AZURE_OPENAI=True # set to False if you are not using Azure OpenAI
       - AZURE_OPENAI_DEPLOYMENT_NAME= # required if using Azure OpenAI
       - AZURE_OPENAI_ENDPOINT= # required if using Azure OpenAI
-      - OPENAI_API_KEY= # always required
+      - OPENAI_API_KEY= # required if using OpenAI and not required if using Azure OpenAI with Azure AD 
       - OPENAI_ORG_ID= # required if using OpenAI
     networks:
       - backend_services

--- a/src/ai-service/requirements.txt
+++ b/src/ai-service/requirements.txt
@@ -5,3 +5,4 @@ pytest==7.3.1
 httpx
 pyyaml
 semantic-kernel==0.3.1.dev0
+azure.identity==1.14.0


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This change is to enable Azure AD auth support in the ai-service so that auth can use either OpenAI API key or Azure AD Workload Identity

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
*  Log into Azure CLI
*  Open terminal and run `make azure-ai` from root of the repo

```
git clone https://github.com/pauldotyu/aks-store-demo
cd aks-store-demo
git checkout aoai-workload-identity
make azure-ai
```

## What to Check
Verify that the following are valid
* Get the public IP of the `store-admin` service and browse to the site
* Ensure you can add a new product with an OpenAI generated product description
* To test workload identity, run through sections 3 and 4 in this [lab guide](https://moaw.dev/workshop/?src=gh%3Apauldotyu%2Fmoaw%2Fsecure-aoai-aks%2Fworkshops%2Fsecure-aoai-aks%2F&step=2)

## Other Information
<!-- Add any other helpful information that may be needed here. -->