### PR TITLE
Fix insecure websocket for store-front and store-admin and remove tls requirement for mongodb from makeline-service

### DIFF
--- a/src/makeline-service/mongodb.go
+++ b/src/makeline-service/mongodb.go
@@ -51,8 +51,7 @@ func connectToMongoDB() (*mongo.Collection, error) {
 			SetAuth(options.Credential{
 				Username: mongoUser,
 				Password: mongoPassword,
-			}).
-			SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+			})
 	}
 
 	mongoClient, err := mongo.Connect(ctx, clientOptions)

--- a/src/makeline-service/mongodb.go
+++ b/src/makeline-service/mongodb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"net/http"
 	"os"
@@ -49,9 +50,10 @@ func connectToMongoDB() (*mongo.Collection, error) {
 		clientOptions = options.Client().ApplyURI(mongoUri).
 			SetAuth(options.Credential{
 				AuthSource: mongoDb,
-				Username: mongoUser,
-				Password: mongoPassword,
-			})
+				Username:   mongoUser,
+				Password:   mongoPassword,
+			}).
+			SetTLSConfig(&tls.Config{InsecureSkipVerify: false})
 	}
 
 	mongoClient, err := mongo.Connect(ctx, clientOptions)

--- a/src/makeline-service/mongodb.go
+++ b/src/makeline-service/mongodb.go
@@ -48,6 +48,7 @@ func connectToMongoDB() (*mongo.Collection, error) {
 	} else {
 		clientOptions = options.Client().ApplyURI(mongoUri).
 			SetAuth(options.Credential{
+				AuthSource: mongoDb,
 				Username: mongoUser,
 				Password: mongoPassword,
 			})

--- a/src/makeline-service/mongodb.go
+++ b/src/makeline-service/mongodb.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"log"
 	"net/http"
 	"os"

--- a/src/store-admin/vue.config.js
+++ b/src/store-admin/vue.config.js
@@ -12,6 +12,8 @@ module.exports = defineConfig({
     port: 8081,
     host: '0.0.0.0',
     allowedHosts: 'all',
+    client: false,
+    webSocketServer: false,
     setupMiddlewares: (middlewares, devServer) => {
       
       if (!devServer) {

--- a/src/store-front/vue.config.js
+++ b/src/store-front/vue.config.js
@@ -11,7 +11,8 @@ module.exports = defineConfig({
     port: 8080,
     host: '0.0.0.0',
     allowedHosts: 'all',
-    
+    client: false,
+    webSocketServer: false,    
     setupMiddlewares: (middlewares, devServer) => {
       
       if (!devServer) {


### PR DESCRIPTION
## Purpose
Fix insecure websocket for store-front and store-admin and remove tls requirement for mongodb from makeline-service* ...
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
Fix insecure websocket for store-front and store-admin and remove tls requirement for mongodb from makeline-service
When deploy  store-front and store-admin behind of nginx ingress with https, the default web dev server will start websocket because by default it is using ws, so insecure webclient error will reported.

For mongodb connection, also remove tls support

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->