### PR TITLE
unable to start ai-service when trying to use public OpenAI

### DIFF
--- a/src/ai-service/routers/LLM.py
+++ b/src/ai-service/routers/LLM.py
@@ -11,7 +11,8 @@ def get_llm():
     useLocalLLM: bool = False
     useAzureOpenAI: bool = False
     kernel = False
-
+    endpoint: str = ''
+    
     if os.environ.get("USE_LOCAL_LLM"):
         useLocalLLM = os.environ.get("USE_LOCAL_LLM").lower() == "true"
 
@@ -24,7 +25,7 @@ def get_llm():
 
     # if useLocalLLM or useAzureOpenAI are set to true, get the endpoint from the environment variables
     if useLocalLLM or useAzureOpenAI:
-        endpoint: str = os.environ.get("AI_ENDPOINT") or os.environ.get("AZURE_OPENAI_ENDPOINT")
+        endpoint = os.environ.get("AI_ENDPOINT") or os.environ.get("AZURE_OPENAI_ENDPOINT")
         
         if isinstance(endpoint, str) == False or endpoint == "":
             raise Exception("AI_ENDPOINT or AZURE_OPENAI_ENDPOINT environment variable must be set when USE_LOCAL_LLM or USE_AZURE_OPENAI is set to true")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Fixes undefined variable when using public OpenAI rather than Azure one

<details><summary>Error stack trace</summary>

```
Using OpenAI and setting up Semantic Kernel
Traceback (most recent call last):
  File "/usr/local/bin/uvicorn", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 410, in main
    run(
  File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 578, in run
    server.run()
  File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 61, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 68, in serve
    config.load()
  File "/usr/local/lib/python3.11/site-packages/uvicorn/config.py", line 473, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/importer.py", line 21, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/main.py", line 2, in <module>
    from routers.description_generator import description
  File "/app/routers/description_generator.py", line 9, in <module>
    kernel, useLocalLLM, endpoint = get_llm()
                                    ^^^^^^^^^
  File "/app/routers/LLM.py", line 70, in get_llm
    return kernel, useLocalLLM, endpoint
                                ^^^^^^^^
UnboundLocalError: cannot access local variable 'endpoint' where it is not associated with a value
```

</details> 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/cvgore/aks-store-demo
cd aks-store-demo
git checkout patch-1
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Use ai-services.yaml file with env variable USE_AZURE_OPENAI set to False.
Also fill both OPENAI_API_KEY and OPENAI_ORG_ID with valid credentials.
```

## What to Check
Verify that the following are valid
* i can use ai-services with public OpenAI

## Other Information
<!-- Add any other helpful information that may be needed here. -->