### PR TITLE
Minor changes to quickstart YAML for AKS Automatic policy. 

### DIFF
--- a/aks-store-ingress-quickstart.yaml
+++ b/aks-store-ingress-quickstart.yaml
@@ -35,6 +35,20 @@ spec:
             limits:
               cpu: 250m
               memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 15672
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 15672
+            failureThreshold: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
           volumeMounts:
             - name: rabbitmq-enabled-plugins
               mountPath: /etc/rabbitmq/enabled_plugins
@@ -89,7 +103,7 @@ spec:
         "kubernetes.io/os": linux
       containers:
         - name: order-service
-          image: ghcr.io/azure-samples/aks-store-demo/order-service:latest
+          image: ghcr.io/azure-samples/aks-store-demo/order-service:1da12f1
           ports:
             - containerPort: 3000
           env:
@@ -135,7 +149,7 @@ spec:
             periodSeconds: 3
       initContainers:
         - name: wait-for-rabbitmq
-          image: busybox
+          image: busybox:1.35
           command:
             ["sh", "-c", "until nc -zv rabbitmq 5672; do echo waiting for rabbitmq; sleep 2; done;"]
           resources:
@@ -177,7 +191,7 @@ spec:
         "kubernetes.io/os": linux
       containers:
         - name: product-service
-          image: ghcr.io/azure-samples/aks-store-demo/product-service:latest
+          image: ghcr.io/azure-samples/aks-store-demo/product-service:5fc5970
           ports:
             - containerPort: 3002
           env:
@@ -236,7 +250,7 @@ spec:
         "kubernetes.io/os": linux
       containers:
         - name: store-front
-          image: ghcr.io/azure-samples/aks-store-demo/store-front:latest
+          image: ghcr.io/azure-samples/aks-store-demo/store-front:942610d
           ports:
             - containerPort: 8080
               name: store-front


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Changes made to aks-store-ingress-quickstart.yaml to enable deployment in accordance with the AKS Automatic Getting Started guide. Due to AKS Automatic Policy the current quickstart is not able to be deployed and is blocked at point of admission due to:
- Images being tagged with latest as opposed to pinned versions.
- No Readiness or Liveness probes for RabbitMQ. 

As a result:
- I have pinned the store image versions to latest image digest.
- Pinned busybox version to 1:35 
- Added liveness and readiness probes for RabbitMQ.

I did debate creating a seperate file for automatic and have the docs changed in https://learn.microsoft.com/en-us/azure/aks/automatic/quick-automatic-managed-network?pivots=azure-portal to allow for this file to continue using latest tags but in reality this would then mean going forward their would be a fairly useless duplication of effort imo. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Follow the quickstart https://learn.microsoft.com/en-us/azure/aks/automatic/quick-automatic-managed-network?pivots=azure-portal and observe policy blocks. Apply the updated file to automatic cluster and observe admission and working applications. 

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->