### PR TITLE
Bump AVM managed-cluster module to 0.14.0 (GA API 2025-10-01)

### DIFF
--- a/infra/bicep/kubernetes.bicep
+++ b/infra/bicep/kubernetes.bicep
@@ -12,7 +12,7 @@ param tags object
 
 // https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/container-service/managed-cluster
 // https://mcr.microsoft.com/v2/bicep/avm/res/container-service/managed-cluster/tags/list
-module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.9.0' = {
+module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.14.0' = {
   name: 'managedClusterDeployment'
   params: {
     name: 'aks-${nameSuffix}'
@@ -28,26 +28,43 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.9.0
     networkPluginMode: 'overlay'
     networkPolicy: 'cilium'
     networkDataplane: 'cilium'
-    autoNodeOsUpgradeProfileUpgradeChannel: 'SecurityPatch'
+    autoUpgradeProfile: {
+      upgradeChannel: 'stable'
+      nodeOSUpgradeChannel: 'SecurityPatch'
+    }
     enableOidcIssuerProfile: true
-    enableWorkloadIdentity: true
+    securityProfile: {
+      workloadIdentity: {
+        enabled: true
+      }
+    }
     enableKeyvaultSecretsProvider: true
     enableSecretRotation: true
-    enableAzureMonitorProfileMetrics: configureMonitorSettings
-    enableContainerInsights: configureMonitorSettings
-    disablePrometheusMetricsScraping: !configureMonitorSettings
+    azureMonitorProfile: configureMonitorSettings
+      ? {
+          metrics: {
+            enabled: true
+            kubeStateMetrics: {
+              metricLabelsAllowlist: ''
+              metricAnnotationsAllowList: ''
+            }
+          }
+        }
+      : null
     monitoringWorkspaceResourceId: configureMonitorSettings ? logsWorkspaceResourceId : null
     aadProfile: {
-      aadProfileEnableAzureRBAC: true
-      aadProfileManaged: true
+      enableAzureRBAC: true
+      managed: true
     }
     managedIdentities: {
       systemAssigned: true
     }
     publicNetworkAccess: 'Enabled'
-    authorizedIPRanges: [
-      currentIpAddress
-    ]
+    apiServerAccessProfile: {
+      authorizedIPRanges: [
+        currentIpAddress
+      ]
+    }
     roleAssignments: [
       {
         principalId: currentUserObjectId


### PR DESCRIPTION
The module is pinned to `0.9.0`, which uses AKS API `2024-09-02-preview`. Azure [retired that API on July 1, 2026](https://learn.microsoft.com/azure/aks/concepts-preview-api-life-cycle), so `azd up` fails for everyone:

```
NoRegisteredProviderFound: No registered resource provider found for location 'westus3'
and API version '2024-09-02-preview' for type 'managedClusters'.
```

Not region-specific — I hit it in `westus3`, `eastus2`, and `swedencentral`.

This goes to `0.14.0`, which uses the GA API `2025-10-01` so it won't expire again. `0.12.0+` replaced some flat params with pass-through profile objects, so a few had to move:

- `autoNodeOsUpgradeProfileUpgradeChannel` → `autoUpgradeProfile`
- `enableWorkloadIdentity` → `securityProfile.workloadIdentity`
- `enableAzureMonitorProfileMetrics` → `azureMonitorProfile.metrics`
- `authorizedIPRanges` → `apiServerAccessProfile.authorizedIPRanges`
- `aadProfileEnableAzureRBAC` / `aadProfileManaged` → `enableAzureRBAC` / `managed`

`enableContainerInsights` and `disablePrometheusMetricsScraping` are dropped — `azureMonitorProfile.containerInsights` doesn't exist in the GA API. Container Insights still comes from the `omsagent` addon via `monitoringWorkspaceResourceId`, unchanged.

Worth flagging: the last two are easy to get wrong. `0.14.0` passes these objects straight to ARM, so wrong property names compile fine and get silently dropped — `aadProfile` would have quietly disabled Azure RBAC.

### Testing

Deployed to `westus3` with observability enabled — succeeded in 6m. Cluster properties (`aadProfile`, `autoUpgradeProfile`, `securityProfile`, `azureMonitorProfile`, `omsagent`, `apiServerAccessProfile`) match a cluster built with the old module. Resources deleted after.
