### PR TITLE
Add OCI Artifact creation when new release created.

### DIFF
--- a/.github/workflows/package-oci-artifact.yaml
+++ b/.github/workflows/package-oci-artifact.yaml
@@ -1,0 +1,89 @@
+name: package-oci-artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/**"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: package-oci-artifact-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-oci-artifact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Set up ORAS CLI
+        uses: oras-project/setup-oras@v1
+
+      - name: Set artifact metadata
+        id: metadata
+        shell: bash
+        run: |
+          repository="$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          tag="$(yq -r .appVersion ./charts/aks-store-demo/Chart.yaml)"
+
+          if [[ -z "$tag" || "$tag" == "null" ]]; then
+            echo "Could not read appVersion from charts/aks-store-demo/Chart.yaml" >&2
+            exit 1
+          fi
+
+          echo "artifact=ghcr.io/$repository" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "revision=$tag@sha1:$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Package and push Flux OCI artifact
+        env:
+          ARTIFACT: ${{ steps.metadata.outputs.artifact }}
+          TAG: ${{ steps.metadata.outputs.tag }}
+          REVISION: ${{ steps.metadata.outputs.revision }}
+          CREATED: ${{ steps.metadata.outputs.created }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          workdir="$(mktemp -d)"
+          # Layer layout and media types must match what Flux source-controller expects.
+          tar -czf "$workdir/artifact.tgz" -C "$GITHUB_WORKSPACE/kustomize/base" .
+          echo '{}' > "$workdir/config.json"
+
+          cd "$workdir"
+
+          oras push "$ARTIFACT:$TAG" \
+            --config "config.json:application/vnd.cncf.flux.config.v1+json" \
+            --annotation "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --annotation "org.opencontainers.image.revision=$REVISION" \
+            --annotation "org.opencontainers.image.created=$CREATED" \
+            --annotation "org.opencontainers.image.description=AKS Store Demo application" \
+            "artifact.tgz:application/vnd.cncf.flux.content.v1.tar+gzip"
+
+          oras tag "$ARTIFACT:$TAG" latest
+
+      - name: Show artifact reference
+        env:
+          ARTIFACT: ${{ steps.metadata.outputs.artifact }}
+          TAG: ${{ steps.metadata.outputs.tag }}
+        run: echo "Published oci://$ARTIFACT:$TAG"

--- a/.github/workflows/package-oci-artifact.yaml
+++ b/.github/workflows/package-oci-artifact.yaml
@@ -1,11 +1,15 @@
 name: package-oci-artifact
 
 on:
+  release:
+    types: [published]
+
   push:
     branches:
       - main
     paths:
       - "charts/**"
+      - "kustomize/**"
 
   workflow_dispatch:
 

--- a/.github/workflows/package-oci-artifact.yaml
+++ b/.github/workflows/package-oci-artifact.yaml
@@ -1,15 +1,15 @@
 name: package-oci-artifact
 
 on:
-  release:
-    types: [published]
-
+  release:
+    types: [published]
+
   push:
     branches:
       - main
     paths:
       - "charts/**"
-      - "kustomize/**"
+      - "kustomize/**"
 
   workflow_dispatch:
 
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up ORAS CLI
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Set artifact metadata
         id: metadata


### PR DESCRIPTION
## Purpose
Add OCI Artifact build when a new release is made. The Artifact is keyed off the version held in the Helm charts which reflects Releases in GitHub.

ORAS is used to build the artifact which has additional metadata added to make it easier to consume the artifact via Flux for "Gitless GitOps" support (see [Flux D2 architecture](https://control-plane.io/posts/d2-reference-architecture-guide/)).

## Does this introduce a breaking change?

No

## Pull Request Type
What kind of change does this Pull Request introduce?

Feature, enhancing Continuous Deployment options by providing an OCI Artifact on release.

## How to Test

The new build GitHub Action has `workflow dispatch` enabled, so can be manually invoked to test. The result should be a new artifact held in the GitHub container registry associated with the repository.